### PR TITLE
Fix bdlb_guidutil.h link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Important new features include:
       * [`bdlt::CurrentTime`](https://github.com/bloomberg/bde/blob/master/groups/bdl/bdlt/bdlt_currenttime.h)
   * [`bslx`](https://github.com/bloomberg/bde/blob/master/groups/bsl/bslx/doc/bslx.txt) -  A package that provides a framework for externalizing and unexternalizing value types.
   * [`bdlma_localsequentialallocator`](https://github.com/bloomberg/bde/blob/master/groups/bdl/bdlma/bdlma_localsequentialallocator.h) - An aide to creating stack-based buffered-sequential allocators.
-  * [`bdlb_guid`](https://github.com/bloomberg/bde/blob/master/groups/bdl/bdlb/bdlb_guid.h) and [`bdlb_guidutil`](https://github.com/bloomberg/bde/blob/master/groups/bdl/bdlb/bdlb_guid.h) - Provide classes for creating and Globally Unique IDentifiers (GUIDs, version 4 per [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt))
+  * [`bdlb_guid`](https://github.com/bloomberg/bde/blob/master/groups/bdl/bdlb/bdlb_guid.h) and [`bdlb_guidutil`](https://github.com/bloomberg/bde/blob/master/groups/bdl/bdlb/bdlb_guidutil.h) - Provide classes for creating and Globally Unique IDentifiers (GUIDs, version 4 per [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt))
 
 See [BDE 2.23 Release Notes](https://github.com/bloomberg/bde/wiki/BDE-2.23-Release-Notes).
 


### PR DESCRIPTION
The link provided for bdlb_guidutil.h in README.md was directing to bdlb_guid.h. The fix for this was to correct the typo, providing the appropriate link for bdlb_guidutil.h.